### PR TITLE
docs: fix link to cache documentation

### DIFF
--- a/website/pages/docs/customization/cache.mdx
+++ b/website/pages/docs/customization/cache.mdx
@@ -1,7 +1,7 @@
 ---
 section: Customization
-title: Colors
-slug: /docs/colors/
+title: Cache
+slug: /docs/cache/
 order: 4
 ---
 


### PR DESCRIPTION
## Summary

Change the slug and title for the new cache documentation page
